### PR TITLE
Implement task assignment to users and update tests

### DIFF
--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -13,10 +13,31 @@ namespace TodoApp.API.Controllers
 
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] CreateTaskCommand command)
-            => Ok(await _mediator.Send(command));
+        {
+            try
+            {
+                var result = await _mediator.Send(command);
+                return Ok(result);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
 
         [HttpGet]
-        public async Task<IActionResult> GetAll()
-            => Ok(await _mediator.Send(new GetAllTasksQuery()));
+        public async Task<IActionResult> GetAll([FromQuery] int? userId)
+        {
+            if (userId.HasValue)
+            {
+                var result = await _mediator.Send(new GetTasksByUserQuery(userId.Value));
+                return Ok(result);
+            }
+            else
+            {
+                var result = await _mediator.Send(new GetAllTasksQuery());
+                return Ok(result);
+            }
+        }
     }
 }

--- a/Application/TSK001Tasks/TasksFeatureSetup.cs
+++ b/Application/TSK001Tasks/TasksFeatureSetup.cs
@@ -9,6 +9,7 @@ namespace TodoApp.Application.TSK001Tasks
         {
             services.AddScoped<IRequestHandler<CreateTaskCommand, TaskItem>, CreateTaskHandler>();
             services.AddScoped<IRequestHandler<GetAllTasksQuery, List<TaskItem>>, GetAllTasksHandler>();
+            services.AddScoped<IRequestHandler<GetTasksByUserQuery, List<TaskItem>>, GetTasksByUserHandler>();
             return services;
         }
     }

--- a/Domain/Entities/TaskItem.cs
+++ b/Domain/Entities/TaskItem.cs
@@ -5,5 +5,7 @@ namespace TodoApp.Domain.Entities
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
         public bool IsCompleted { get; set; } = false;
+        public int UserId { get; set; }
+        public User? User { get; set; }
     }
 }

--- a/tests/Application.Tests/Builders/TaskItemBuilder.cs
+++ b/tests/Application.Tests/Builders/TaskItemBuilder.cs
@@ -7,6 +7,7 @@ namespace TodoApp.tests.Application.Tests.Builders
         private int _id = 1;
         private string _title = "Test Task";
         private bool _isCompleted = false;
+        private int _userId = 0;
 
         public TaskItemBuilder WithId(int id)
         {
@@ -38,13 +39,20 @@ namespace TodoApp.tests.Application.Tests.Builders
             return this;
         }
 
+        public TaskItemBuilder WithUserId(int userId)
+        {
+            _userId = userId;
+            return this;
+        }
+
         public TaskItem Build()
         {
             return new TaskItem
             {
                 Id = _id,
                 Title = _title,
-                IsCompleted = _isCompleted
+                IsCompleted = _isCompleted,
+                UserId = _userId
             };
         }
 


### PR DESCRIPTION
This pull request introduces user association to tasks and adds the ability to filter tasks by user. It also improves error handling for task creation and updates tests to cover the new functionality.

**User association and filtering:**

* Added `UserId` and `User` properties to the `TaskItem` entity to associate tasks with users. (`Domain/Entities/TaskItem.cs`)
* Implemented `GetTasksByUserQuery` and its handler to fetch tasks for a specific user, and registered the handler for dependency injection. (`Application/TSK001Tasks/TasksFeature.cs`, `Application/TSK001Tasks/TasksFeatureSetup.cs`) [[1]](diffhunk://#diff-af2d30a8f9ce44a25579b799e9f4412bea196346740575fe923321ee23579a13L8-R18) [[2]](diffhunk://#diff-f61a2d331cbb2e5c10fc30347e356ff5d3c13cf8bf2d799e916827edb3407ee9R12)
* Updated `TasksController` to support filtering tasks by user via the `userId` query parameter. (`API/Controllers/TasksController.cs`)

**Task creation improvements:**

* Modified `CreateTaskCommand` and handler to require and validate a `UserId` when creating a task, returning a `BadRequest` if the user is invalid. (`Application/TSK001Tasks/TasksFeature.cs`, `API/Controllers/TasksController.cs`) [[1]](diffhunk://#diff-af2d30a8f9ce44a25579b799e9f4412bea196346740575fe923321ee23579a13L17-R29) [[2]](diffhunk://#diff-f16f7feba7b6e68359bcfba76f7804030923373deaf4a3db2670e018601a29c8L16-R41)

**Test updates:**

* Extended the `TaskItemBuilder` to support setting `UserId`, and updated tests to create tasks with users and verify filtering by user. (`tests/Application.Tests/Builders/TaskItemBuilder.cs`, `tests/Application.Tests/TSK001Tasks/TasksFeatureTests.cs`) [[1]](diffhunk://#diff-17ffce45db3deb177fbf59274d4bebbb2aefe15d3c8e36069eb367d7aada736dR10) [[2]](diffhunk://#diff-17ffce45db3deb177fbf59274d4bebbb2aefe15d3c8e36069eb367d7aada736dR42-R55) [[3]](diffhunk://#diff-3ef7300cfdf208406989bbd109edba81c63361187abe1b53dbd0ce3feb08e8e5L30-R35) [[4]](diffhunk://#diff-3ef7300cfdf208406989bbd109edba81c63361187abe1b53dbd0ce3feb08e8e5L54-R64) [[5]](diffhunk://#diff-3ef7300cfdf208406989bbd109edba81c63361187abe1b53dbd0ce3feb08e8e5R125-R147)