### PR TITLE
feat: add Docker and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+bin
+obj
+tests
+.idea
+docs
+wiki
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY TodoApp.csproj .
+RUN dotnet restore TodoApp.csproj
+COPY . .
+RUN dotnet publish TodoApp.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "TodoApp.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  api:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+    environment:
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=todoapp;Username=todoapp;Password=todoapp_dev
+
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=todoapp
+      - POSTGRES_USER=todoapp
+      - POSTGRES_PASSWORD=todoapp_dev
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Adds Docker support for the Todo app:

- **Dockerfile**: Multi-stage build using `sdk:8.0` for build and `aspnet:8.0` for runtime, exposes port 8080
- **docker-compose.yml**: API service with PostgreSQL 16 dependency, named volume for data persistence
- **.dockerignore**: Excludes unnecessary files from the build context

## Usage

```bash
docker-compose up --build
```

The API will be available at `http://localhost:8080`.