### PR TITLE
feat: add CORS configuration

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,17 @@ builder.Services
 
 builder.Services.AddControllers();
 
+// Note: In production, AllowAnyOrigin should be replaced with specific origins from configuration
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("DefaultCorsPolicy", policy =>
+    {
+        policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
+    });
+});
+
 var app = builder.Build();
+app.UseCors("DefaultCorsPolicy");
 app.MapControllers();
 app.Run();
 


### PR DESCRIPTION
## Summary

Adds CORS configuration to the ASP.NET Core Todo app with a `DefaultCorsPolicy` that allows any origin, method, and header.

### Changes
- Added `AddCors` service registration with `DefaultCorsPolicy`
- Added `UseCors("DefaultCorsPolicy")` middleware before `MapControllers`
- Included a comment noting that `AllowAnyOrigin` should be replaced with specific origins from configuration in production

### Note
The permissive CORS policy is suitable for development. For production deployments, origins should be restricted to known frontend domains via configuration.