### PR TITLE
feat: add rate limiting

### DIFF
--- a/API/Controllers/CommentsController.cs
+++ b/API/Controllers/CommentsController.cs
@@ -1,11 +1,13 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using TodoApp.Application.CMT003Comments;
 
 namespace TodoApp.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [EnableRateLimiting("fixed")]
     public class CommentsController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -1,11 +1,13 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using TodoApp.Application.TSK001Tasks;
 
 namespace TodoApp.API.Controllers
 {
     [ApiController]
     [Route("api/tasks")]
+    [EnableRateLimiting("fixed")]
     public class TasksController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -1,11 +1,13 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using TodoApp.Application.USR002Users;
 
 namespace TodoApp.API.Controllers
 {
     [ApiController]
     [Route("api/users")]
+    [EnableRateLimiting("fixed")]
     public class UsersController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
-﻿using MediatR;
+﻿using System.Threading.RateLimiting;
+using MediatR;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
@@ -16,7 +18,20 @@ builder.Services
 
 builder.Services.AddControllers();
 
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = 429;
+    options.AddFixedWindowLimiter("fixed", opt =>
+    {
+        opt.PermitLimit = 100;
+        opt.Window = TimeSpan.FromMinutes(1);
+        opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+        opt.QueueLimit = 2;
+    });
+});
+
 var app = builder.Build();
+app.UseRateLimiter();
 app.MapControllers();
 app.Run();
 


### PR DESCRIPTION
## Summary

Adds ASP.NET Core built-in rate limiting middleware to the Todo app.

### Changes

- **Program.cs**: Configured fixed window rate limiter (100 requests/minute, queue limit of 2) with 429 rejection status code. Added `UseRateLimiter()` to the middleware pipeline.
- **TasksController, UsersController, CommentsController**: Applied `[EnableRateLimiting("fixed")]` attribute to all controllers.

### Configuration

| Setting | Value |
|---------|-------|
| Permit Limit | 100 requests |
| Window | 1 minute |
| Queue Processing Order | Oldest First |
| Queue Limit | 2 |
| Rejection Status Code | 429 (Too Many Requests) |