### PR TITLE
feat: add API versioning

### DIFF
--- a/API/Controllers/CommentsController.cs
+++ b/API/Controllers/CommentsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using TodoApp.Application.CMT003Comments;
@@ -5,7 +6,8 @@ using TodoApp.Application.CMT003Comments;
 namespace TodoApp.API.Controllers
 {
     [ApiController]
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/comments")]
     public class CommentsController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using TodoApp.Application.TSK001Tasks;
@@ -5,7 +6,8 @@ using TodoApp.Application.TSK001Tasks;
 namespace TodoApp.API.Controllers
 {
     [ApiController]
-    [Route("api/tasks")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/tasks")]
     public class TasksController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using TodoApp.Application.USR002Users;
@@ -5,7 +6,8 @@ using TodoApp.Application.USR002Users;
 namespace TodoApp.API.Controllers
 {
     [ApiController]
-    [Route("api/users")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/users")]
     public class UsersController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
@@ -13,6 +14,21 @@ builder.Services.AddMediatR(typeof(Program).Assembly);
 builder.Services
     .AddTasksFeature()
     .AddUsersFeature();
+
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = ApiVersionReader.Combine(
+        new UrlSegmentApiVersionReader(),
+        new QueryStringApiVersionReader("api-version"),
+        new HeaderApiVersionReader("X-Api-Version"));
+}).AddApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
 
 builder.Services.AddControllers();
 


### PR DESCRIPTION
## Summary

Adds API versioning support using `Asp.Versioning.Http` and `Asp.Versioning.Mvc.ApiExplorer`.

### Changes

- **Program.cs**: Configured API versioning with URL segment, query string (`api-version`), and header (`X-Api-Version`) readers. Default version is 1.0.
- **TasksController**: Added `[ApiVersion("1.0")]` and versioned route `api/v{version:apiVersion}/tasks`
- **UsersController**: Added `[ApiVersion("1.0")]` and versioned route `api/v{version:apiVersion}/users`
- **CommentsController**: Added `[ApiVersion("1.0")]` and versioned route `api/v{version:apiVersion}/comments`

### API Access

Endpoints can now be accessed via:
- URL segment: `/api/v1/tasks`
- Query string: `/api/v1/tasks?api-version=1.0`
- Header: `X-Api-Version: 1.0`

Unversioned requests default to v1.0.