### PR TITLE
feat: add global exception handling middleware

### DIFF
--- a/API/Controllers/CommentsController.cs
+++ b/API/Controllers/CommentsController.cs
@@ -14,15 +14,8 @@ namespace TodoApp.API.Controllers
         [HttpPost]
         public async Task<IActionResult> AddComment([FromBody] AddCommentCommand command)
         {
-            try
-            {
-                var comment = await _mediator.Send(command);
-                return Ok(comment);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var comment = await _mediator.Send(command);
+            return Ok(comment);
         }
 
         [HttpGet]

--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -14,15 +14,8 @@ namespace TodoApp.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] CreateTaskCommand command)
         {
-            try
-            {
-                var result = await _mediator.Send(command);
-                return Ok(result);
-            }
-            catch (ArgumentException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            var result = await _mediator.Send(command);
+            return Ok(result);
         }
 
         [HttpGet]

--- a/API/Middleware/ExceptionHandlingMiddleware.cs
+++ b/API/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TodoApp.API.Middleware;
+
+public class ExceptionHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+    public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unhandled exception occurred while processing the request.");
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    private static Task HandleExceptionAsync(HttpContext context, Exception exception)
+    {
+        var (statusCode, title) = exception switch
+        {
+            ArgumentException => ((int)HttpStatusCode.BadRequest, "Bad Request"),
+            KeyNotFoundException => ((int)HttpStatusCode.NotFound, "Not Found"),
+            InvalidOperationException => ((int)HttpStatusCode.Conflict, "Conflict"),
+            _ => ((int)HttpStatusCode.InternalServerError, "Internal Server Error")
+        };
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = exception.Message,
+            Instance = context.Request.Path
+        };
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/problem+json";
+
+        return context.Response.WriteAsJsonAsync(problemDetails);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
 using TodoApp.Application.USR002Users;
+using TodoApp.API.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,6 +18,7 @@ builder.Services
 builder.Services.AddControllers();
 
 var app = builder.Build();
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.MapControllers();
 app.Run();
 


### PR DESCRIPTION
## Summary

Adds global exception handling middleware that catches all unhandled exceptions and returns standardized RFC 7807 ProblemDetails JSON responses.

## Changes

- **New**: `API/Middleware/ExceptionHandlingMiddleware.cs` — catches exceptions and maps them to appropriate HTTP status codes:
  - `ArgumentException` → 400 Bad Request
  - `KeyNotFoundException` → 404 Not Found
  - `InvalidOperationException` → 409 Conflict
  - All others → 500 Internal Server Error
- **Updated**: `Program.cs` — registers the middleware before `MapControllers()`
- **Simplified**: `TasksController` and `CommentsController` — removed redundant try/catch blocks now handled by the middleware

## Testing

- `dotnet build` passes successfully
- Middleware is registered early in the pipeline to catch all downstream exceptions