### PR TITLE
feat: add JWT authentication

### DIFF
--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -1,0 +1,63 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using TodoApp.Infrastructure;
+
+namespace TodoApp.API.Controllers
+{
+    [ApiController]
+    [Route("api/auth")]
+    public class AuthController : ControllerBase
+    {
+        private readonly AppDbContext _dbContext;
+        private readonly IConfiguration _configuration;
+
+        public AuthController(AppDbContext dbContext, IConfiguration configuration)
+        {
+            _dbContext = dbContext;
+            _configuration = configuration;
+        }
+
+        [HttpPost("token")]
+        public async Task<IActionResult> GetToken([FromBody] LoginRequest request)
+        {
+            var user = await _dbContext.Users
+                .FirstOrDefaultAsync(u => u.Username == request.Username);
+
+            if (user == null)
+                return Unauthorized();
+
+            var key = _configuration["Jwt:Key"] ?? "ThisIsADemoSecretKeyThatShouldBeChanged123!";
+            var issuer = _configuration["Jwt:Issuer"] ?? "TodoApp";
+            var audience = _configuration["Jwt:Audience"] ?? "TodoApp";
+
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+                new Claim(JwtRegisteredClaimNames.Name, user.Username),
+                new Claim(ClaimTypes.Role, "User")
+            };
+
+            var expiresAt = DateTime.UtcNow.AddMinutes(60);
+
+            var token = new JwtSecurityToken(
+                issuer: issuer,
+                audience: audience,
+                claims: claims,
+                expires: expiresAt,
+                signingCredentials: credentials);
+
+            var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+
+            return Ok(new { token = tokenString, expiresAt });
+        }
+    }
+
+    public record LoginRequest(string Username);
+}

--- a/API/Controllers/CommentsController.cs
+++ b/API/Controllers/CommentsController.cs
@@ -1,9 +1,11 @@
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TodoApp.Application.CMT003Comments;
 
 namespace TodoApp.API.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class CommentsController : ControllerBase

--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -1,9 +1,11 @@
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TodoApp.Application.TSK001Tasks;
 
 namespace TodoApp.API.Controllers
 {
+    [Authorize]
     [ApiController]
     [Route("api/tasks")]
     public class TasksController : ControllerBase

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,8 @@
-﻿using MediatR;
+﻿using System.Text;
+using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
 using TodoApp.Application.USR002Users;
@@ -14,9 +17,31 @@ builder.Services
     .AddTasksFeature()
     .AddUsersFeature();
 
+var jwtKey = builder.Configuration["Jwt:Key"] ?? "ThisIsADemoSecretKeyThatShouldBeChanged123!";
+var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "TodoApp";
+var jwtAudience = builder.Configuration["Jwt:Audience"] ?? "TodoApp";
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtIssuer,
+            ValidAudience = jwtAudience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+        };
+    });
+
+builder.Services.AddAuthorization();
 builder.Services.AddControllers();
 
 var app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
 app.MapControllers();
 app.Run();
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Jwt": {
+    "Key": "ThisIsADemoSecretKeyThatShouldBeChanged123!",
+    "Issuer": "TodoApp",
+    "Audience": "TodoApp"
+  }
+}


### PR DESCRIPTION
## Summary

Adds JWT Bearer authentication to the Todo app.

### Changes

- **`API/Controllers/AuthController.cs`** — New controller with `POST /api/auth/token` endpoint that authenticates users by username and returns a signed JWT
- **`Program.cs`** — Configures JWT Bearer authentication and authorization middleware
- **`API/Controllers/TasksController.cs`** — Added `[Authorize]` attribute
- **`API/Controllers/CommentsController.cs`** — Added `[Authorize]` attribute
- **`appsettings.json`** — JWT configuration (Key, Issuer, Audience)

### Auth flow

1. Client calls `POST /api/auth/token` with `{ "username": "..." }`
2. If user exists → returns `{ token, expiresAt }` (60 min expiry)
3. Client includes `Authorization: Bearer <token>` header on subsequent requests to protected endpoints

### Notes

- UsersController and AuthController remain publicly accessible
- TasksController and CommentsController require authentication