### PR TITLE
feat: add Swagger/OpenAPI documentation

### DIFF
--- a/API/Controllers/CommentsController.cs
+++ b/API/Controllers/CommentsController.cs
@@ -4,14 +4,25 @@ using TodoApp.Application.CMT003Comments;
 
 namespace TodoApp.API.Controllers
 {
+    /// <summary>
+    /// Manages comments on task items.
+    /// </summary>
     [ApiController]
     [Route("api/[controller]")]
+    [Produces("application/json")]
     public class CommentsController : ControllerBase
     {
         private readonly IMediator _mediator;
         public CommentsController(IMediator mediator) => _mediator = mediator;
 
+        /// <summary>
+        /// Adds a comment to a task item.
+        /// </summary>
+        /// <param name="command">The comment details including task item ID and content.</param>
+        /// <returns>The newly created comment.</returns>
         [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> AddComment([FromBody] AddCommentCommand command)
         {
             try
@@ -25,7 +36,13 @@ namespace TodoApp.API.Controllers
             }
         }
 
+        /// <summary>
+        /// Retrieves all comments for a specific task item.
+        /// </summary>
+        /// <param name="taskItemId">The ID of the task item to retrieve comments for.</param>
+        /// <returns>A list of comments for the specified task.</returns>
         [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetComments([FromQuery] int taskItemId)
         {
             var comments = await _mediator.Send(new GetCommentsQuery(taskItemId));

--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -4,14 +4,25 @@ using TodoApp.Application.TSK001Tasks;
 
 namespace TodoApp.API.Controllers
 {
+    /// <summary>
+    /// Manages task items in the Todo application.
+    /// </summary>
     [ApiController]
     [Route("api/tasks")]
+    [Produces("application/json")]
     public class TasksController : ControllerBase
     {
         private readonly IMediator _mediator;
         public TasksController(IMediator mediator) => _mediator = mediator;
 
+        /// <summary>
+        /// Creates a new task.
+        /// </summary>
+        /// <param name="command">The task creation details.</param>
+        /// <returns>The newly created task.</returns>
         [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Create([FromBody] CreateTaskCommand command)
         {
             try
@@ -25,7 +36,13 @@ namespace TodoApp.API.Controllers
             }
         }
 
+        /// <summary>
+        /// Retrieves all tasks, optionally filtered by user ID.
+        /// </summary>
+        /// <param name="userId">Optional user ID to filter tasks by assignee.</param>
+        /// <returns>A list of tasks.</returns>
         [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAll([FromQuery] int? userId)
         {
             if (userId.HasValue)

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -4,18 +4,34 @@ using TodoApp.Application.USR002Users;
 
 namespace TodoApp.API.Controllers
 {
+    /// <summary>
+    /// Manages user registration and retrieval.
+    /// </summary>
     [ApiController]
     [Route("api/users")]
+    [Produces("application/json")]
     public class UsersController : ControllerBase
     {
         private readonly IMediator _mediator;
         public UsersController(IMediator mediator) => _mediator = mediator;
 
+        /// <summary>
+        /// Registers a new user.
+        /// </summary>
+        /// <param name="command">The user registration details.</param>
+        /// <returns>The registered user.</returns>
         [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Register([FromBody] RegisterUserCommand command)
             => Ok(await _mediator.Send(command));
 
+        /// <summary>
+        /// Retrieves all registered users.
+        /// </summary>
+        /// <returns>A list of all users.</returns>
         [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAll()
             => Ok(await _mediator.Send(new GetAllUsersQuery()));
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
 using TodoApp.Application.USR002Users;
@@ -15,8 +16,53 @@ builder.Services
     .AddUsersFeature();
 
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "TodoApp API",
+        Version = "v1",
+        Description = "Enterprise-grade Todo application API"
+    });
+
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header using the Bearer scheme. Enter 'Bearer' [space] and then your token.",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+
+    var xmlFilename = $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+    if (File.Exists(xmlPath))
+    {
+        c.IncludeXmlComments(xmlPath);
+    }
+});
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
 app.MapControllers();
 app.Run();
 

--- a/TodoApp.csproj
+++ b/TodoApp.csproj
@@ -5,7 +5,15 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**" />
+    <Content Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="11.0.0" />


### PR DESCRIPTION
## Summary

Adds Swagger/OpenAPI documentation to the Todo application API.

### Changes

- **Program.cs**: Added `AddEndpointsApiExplorer()`, `AddSwaggerGen()` with OpenAPI info and JWT Bearer security definition/requirement, `UseSwagger()` and `UseSwaggerUI()` middleware
- **Controllers**: Added XML documentation comments and `[ProducesResponseType]` attributes to TasksController, UsersController, and CommentsController
- **TodoApp.csproj**: Enabled XML documentation file generation (`GenerateDocumentationFile`) with warning suppression for undocumented members, and excluded test files from main project compilation

### Access

Swagger UI available at `/swagger` when the application is running.