### PR TITLE
feat: add OpenTelemetry tracing and Seq centralized logging

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Serilog;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
 using TodoApp.Application.USR002Users;
@@ -130,6 +132,17 @@ builder.Services.AddRateLimiter(options =>
         opt.QueueLimit = 2;
     });
 });
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddEntityFrameworkCoreInstrumentation()
+        .AddOtlpExporter(opts => opts.Endpoint = new Uri(builder.Configuration["Otel:Endpoint"] ?? "http://localhost:4317")))
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddOtlpExporter(opts => opts.Endpoint = new Uri(builder.Configuration["Otel:Endpoint"] ?? "http://localhost:4317")));
 
 var app = builder.Build();
 app.UseSwagger();

--- a/TodoApp.csproj
+++ b/TodoApp.csproj
@@ -30,6 +30,12 @@
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,6 +17,12 @@
           "path": "logs/log-.txt",
           "rollingInterval": "Day"
         }
+      },
+      {
+        "Name": "Seq",
+        "Args": {
+          "serverUrl": "http://localhost:5341"
+        }
       }
     ],
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
@@ -25,5 +31,8 @@
     "Key": "ThisIsADemoSecretKeyThatShouldBeChanged123!",
     "Issuer": "TodoApp",
     "Audience": "TodoApp"
+  },
+  "Otel": {
+    "Endpoint": "http://localhost:4317"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,12 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
+      - seq
     environment:
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=todoapp;Username=todoapp;Password=todoapp_dev
+      - Serilog__WriteTo__2__Name=Seq
+      - Serilog__WriteTo__2__Args__serverUrl=http://seq:5341
+      - Otel__Endpoint=http://otel-collector:4317
 
   postgres:
     image: postgres:16-alpine
@@ -18,6 +22,14 @@ services:
       - POSTGRES_PASSWORD=todoapp_dev
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  seq:
+    image: datalust/seq:latest
+    ports:
+      - "5341:5341"
+      - "8081:80"
+    environment:
+      - ACCEPT_EULA=Y
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Adds OpenTelemetry observability and Seq centralized logging to the Todo app.

### Changes

- **NuGet packages**: Added OpenTelemetry tracing, metrics, OTLP exporter, EF Core instrumentation, and Serilog Seq sink
- **Program.cs**: Configured OpenTelemetry with ASP.NET Core, HTTP client, and Entity Framework Core instrumentation, exporting via OTLP
- **docker-compose.yml**: Added Seq service (UI on port 8081, ingestion on 5341) and updated API environment for Seq + OTEL
- **appsettings.json**: Added Seq sink to Serilog WriteTo array and Otel endpoint configuration

### How to verify

1. `docker-compose up` — Seq UI available at http://localhost:8081
2. Application logs will stream to Seq automatically
3. Traces and metrics exported via OTLP to configured collector endpoint