### PR TITLE
feat: add domain events with MediatR notifications

### DIFF
--- a/API/Controllers/TasksController.cs
+++ b/API/Controllers/TasksController.cs
@@ -36,6 +36,20 @@ namespace TodoApp.API.Controllers
         }
 
         /// <summary>
+        /// Marks a task as completed.
+        /// </summary>
+        /// <param name="id">The task ID to complete.</param>
+        /// <returns>The completed task.</returns>
+        [HttpPut("{id}/complete")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Complete(int id)
+        {
+            var result = await _mediator.Send(new CompleteTaskCommand(id));
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Retrieves all tasks, optionally filtered by user ID.
         /// </summary>
         /// <param name="userId">Optional user ID to filter tasks by assignee.</param>

--- a/Application/CMT003Comments/CommentsFeature.cs
+++ b/Application/CMT003Comments/CommentsFeature.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Domain.Entities;
+using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
 
 namespace TodoApp.Application.CMT003Comments
@@ -12,7 +13,8 @@ namespace TodoApp.Application.CMT003Comments
     public class AddCommentHandler : IRequestHandler<AddCommentCommand, Comment>
     {
         private readonly AppDbContext _db;
-        public AddCommentHandler(AppDbContext db) => _db = db;
+        private readonly IPublisher _publisher;
+        public AddCommentHandler(AppDbContext db, IPublisher publisher) { _db = db; _publisher = publisher; }
 
         public async Task<Comment> Handle(AddCommentCommand request, CancellationToken cancellationToken)
         {
@@ -33,6 +35,7 @@ namespace TodoApp.Application.CMT003Comments
             };
             _db.Comments.Add(comment);
             await _db.SaveChangesAsync(cancellationToken);
+            await _publisher.Publish(new CommentAddedEvent(comment.Id, comment.TaskItemId, comment.UserId, comment.Text), cancellationToken);
             return comment;
         }
     }

--- a/Application/EventHandlers/CommentEventHandler.cs
+++ b/Application/EventHandlers/CommentEventHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using TodoApp.Domain.Events;
+
+namespace TodoApp.Application.EventHandlers
+{
+    public class CommentEventHandler : INotificationHandler<CommentAddedEvent>
+    {
+        private readonly ILogger<CommentEventHandler> _logger;
+
+        public CommentEventHandler(ILogger<CommentEventHandler> logger) => _logger = logger;
+
+        public Task Handle(CommentAddedEvent notification, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Comment added: {CommentId} on Task {TaskItemId} by User {UserId} - '{Text}'",
+                notification.CommentId, notification.TaskItemId, notification.UserId, notification.Text);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Application/EventHandlers/TaskEventHandler.cs
+++ b/Application/EventHandlers/TaskEventHandler.cs
@@ -1,0 +1,29 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using TodoApp.Domain.Events;
+
+namespace TodoApp.Application.EventHandlers
+{
+    public class TaskEventHandler :
+        INotificationHandler<TaskCreatedEvent>,
+        INotificationHandler<TaskCompletedEvent>
+    {
+        private readonly ILogger<TaskEventHandler> _logger;
+
+        public TaskEventHandler(ILogger<TaskEventHandler> logger) => _logger = logger;
+
+        public Task Handle(TaskCreatedEvent notification, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Task created: {TaskId} - '{Title}' by User {UserId}",
+                notification.TaskId, notification.Title, notification.UserId);
+            return Task.CompletedTask;
+        }
+
+        public Task Handle(TaskCompletedEvent notification, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Task completed: {TaskId} - '{Title}' by User {UserId}",
+                notification.TaskId, notification.Title, notification.UserId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Application/EventHandlers/UserEventHandler.cs
+++ b/Application/EventHandlers/UserEventHandler.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using TodoApp.Domain.Events;
+
+namespace TodoApp.Application.EventHandlers
+{
+    public class UserEventHandler : INotificationHandler<UserRegisteredEvent>
+    {
+        private readonly ILogger<UserEventHandler> _logger;
+
+        public UserEventHandler(ILogger<UserEventHandler> logger) => _logger = logger;
+
+        public Task Handle(UserRegisteredEvent notification, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("User registered: {UserId} - '{Username}'",
+                notification.UserId, notification.Username);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Application/TSK001Tasks/TasksFeature.cs
+++ b/Application/TSK001Tasks/TasksFeature.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Domain.Entities;
+using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
 
 namespace TodoApp.Application.TSK001Tasks
@@ -20,7 +21,8 @@ namespace TodoApp.Application.TSK001Tasks
     public class CreateTaskHandler : IRequestHandler<CreateTaskCommand, TaskItem>
     {
         private readonly AppDbContext _db;
-        public CreateTaskHandler(AppDbContext db) => _db = db;
+        private readonly IPublisher _publisher;
+        public CreateTaskHandler(AppDbContext db, IPublisher publisher) { _db = db; _publisher = publisher; }
 
         public async Task<TaskItem> Handle(CreateTaskCommand request, CancellationToken cancellationToken)
         {
@@ -29,6 +31,7 @@ namespace TodoApp.Application.TSK001Tasks
             var task = new TaskItem { Title = request.Title, UserId = request.UserId, User = user };
             _db.Tasks.Add(task);
             await _db.SaveChangesAsync(cancellationToken);
+            await _publisher.Publish(new TaskCreatedEvent(task.Id, task.Title, task.UserId), cancellationToken);
             return task;
         }
     }
@@ -44,4 +47,22 @@ namespace TodoApp.Application.TSK001Tasks
             => await _db.Tasks.ToListAsync(cancellationToken);
     }
 
+    public record CompleteTaskCommand(int TaskId) : IRequest<TaskItem>;
+
+    public class CompleteTaskHandler : IRequestHandler<CompleteTaskCommand, TaskItem>
+    {
+        private readonly AppDbContext _db;
+        private readonly IPublisher _publisher;
+        public CompleteTaskHandler(AppDbContext db, IPublisher publisher) { _db = db; _publisher = publisher; }
+
+        public async Task<TaskItem> Handle(CompleteTaskCommand request, CancellationToken cancellationToken)
+        {
+            var task = await _db.Tasks.FindAsync([request.TaskId], cancellationToken);
+            if (task == null) throw new KeyNotFoundException($"Task with ID {request.TaskId} not found.");
+            task.IsCompleted = true;
+            await _db.SaveChangesAsync(cancellationToken);
+            await _publisher.Publish(new TaskCompletedEvent(task.Id, task.Title, task.UserId), cancellationToken);
+            return task;
+        }
+    }
 }

--- a/Application/USR002Users/UsersFeature.cs
+++ b/Application/USR002Users/UsersFeature.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using TodoApp.Domain.Entities;
+using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
 
 namespace TodoApp.Application.USR002Users
@@ -10,13 +11,15 @@ namespace TodoApp.Application.USR002Users
     public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, User>
     {
         private readonly AppDbContext _db;
-        public RegisterUserHandler(AppDbContext db) => _db = db;
+        private readonly IPublisher _publisher;
+        public RegisterUserHandler(AppDbContext db, IPublisher publisher) { _db = db; _publisher = publisher; }
 
         public async Task<User> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
         {
             var user = new User { Username = request.Username };
             _db.Users.Add(user);
             await _db.SaveChangesAsync(cancellationToken);
+            await _publisher.Publish(new UserRegisteredEvent(user.Id, user.Username), cancellationToken);
             return user;
         }
     }

--- a/Domain/Events/CommentAddedEvent.cs
+++ b/Domain/Events/CommentAddedEvent.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace TodoApp.Domain.Events
+{
+    public record CommentAddedEvent(int CommentId, int TaskItemId, int UserId, string Text) : INotification;
+}

--- a/Domain/Events/TaskCompletedEvent.cs
+++ b/Domain/Events/TaskCompletedEvent.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace TodoApp.Domain.Events
+{
+    public record TaskCompletedEvent(int TaskId, string Title, int UserId) : INotification;
+}

--- a/Domain/Events/TaskCreatedEvent.cs
+++ b/Domain/Events/TaskCreatedEvent.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace TodoApp.Domain.Events
+{
+    public record TaskCreatedEvent(int TaskId, string Title, int UserId) : INotification;
+}

--- a/Domain/Events/UserRegisteredEvent.cs
+++ b/Domain/Events/UserRegisteredEvent.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace TodoApp.Domain.Events
+{
+    public record UserRegisteredEvent(int UserId, string Username) : INotification;
+}


### PR DESCRIPTION
## Summary

Adds domain events using MediatR notifications to demonstrate event-driven architecture within the monolith.

## Changes

### Domain Events (`Domain/Events/`)
- `TaskCreatedEvent` - published when a new task is created
- `TaskCompletedEvent` - published when a task is marked complete
- `UserRegisteredEvent` - published when a new user registers
- `CommentAddedEvent` - published when a comment is added to a task

### Event Handlers (`Application/EventHandlers/`)
- `TaskEventHandler` - logs task created/completed events
- `UserEventHandler` - logs user registration events
- `CommentEventHandler` - logs comment added events

### Feature Updates
- `CreateTaskHandler` now publishes `TaskCreatedEvent` after saving
- `RegisterUserHandler` now publishes `UserRegisteredEvent` after saving
- `AddCommentHandler` now publishes `CommentAddedEvent` after saving
- New `CompleteTaskCommand` + handler that marks a task complete and publishes `TaskCompletedEvent`
- New `PUT /api/v1/tasks/{id}/complete` endpoint

### Architecture Pattern
Events are published after successful persistence, allowing loosely-coupled handlers to react (logging now, but extensible to notifications, read model updates, etc.).