### PR TITLE
docs: update documentation for React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker)](docker-compose.yml)
 [![Swagger](https://img.shields.io/badge/API-Swagger%2FOpenAPI-85EA2D?logo=swagger)](http://localhost:8080/swagger)
 
-> A production-ready .NET 8 Todo application demonstrating enterprise architecture patterns, CQRS with MediatR, and feature-sliced design — all in a maintainable, testable demo.
+> A production-ready .NET 8 Todo application with a React frontend, demonstrating enterprise architecture patterns, CQRS with MediatR, and feature-sliced design — all in a maintainable, testable demo.
 
 ---
 
@@ -18,10 +18,45 @@ The goal is to provide a reference implementation that balances pragmatism with 
 
 ---
 
+## Frontend
+
+The application includes a **React Single Page Application** that provides a modern, responsive user interface.
+
+| Technology | Purpose |
+|-----------|---------|
+| React 18 | UI component library |
+| TypeScript | Type-safe development |
+| Vite | Build tool & dev server |
+| Tailwind CSS | Utility-first styling |
+| TanStack Query | Server state & caching |
+
+### Pages
+
+- **Login** — JWT authentication flow
+- **Dashboard** — Overview of tasks and activity
+- **Tasks** — Full task management with comments panel
+- **Users** — User directory
+- **Health** — System health monitoring
+
+### Running the Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Available at `http://localhost:3000` in development. Vite proxies API requests to the backend at `localhost:5000`.
+
+In production (Docker), the frontend is served via **nginx** with API proxying configured in the container.
+
+---
+
 ## Architecture
 
 ```mermaid
 graph TD
+    F[Frontend Layer<br/>React SPA] -->|REST/JSON| A
     A[API Layer<br/>Controllers & Middleware] --> B[Application Layer<br/>Feature Slices & MediatR Handlers]
     B --> C[Domain Layer<br/>Entities & Business Rules]
     B --> D[Infrastructure Layer<br/>EF Core & Persistence]
@@ -55,6 +90,11 @@ Each feature folder contains:
 | Entity Framework Core | 9.0.6 | ORM & data access |
 | MediatR | 11.0 | CQRS & mediator pattern |
 | PostgreSQL | 16 | Production database |
+| React | 18 | Frontend UI library |
+| TypeScript | 5.x | Type-safe frontend development |
+| Vite | 5.x | Frontend build tool & dev server |
+| Tailwind CSS | 3.x | Utility-first CSS framework |
+| TanStack Query | 5.x | Server state management |
 | Serilog | 8.0.3 | Structured logging |
 | Swashbuckle | 6.9.0 | Swagger/OpenAPI documentation |
 | JWT Bearer | 8.0.0 | Authentication |
@@ -85,13 +125,25 @@ dotnet run
 
 The API will be available at `http://localhost:5000` with Swagger UI at `/swagger`.
 
-**Using Docker Compose (PostgreSQL):**
+**Frontend (React SPA):**
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend will be available at `http://localhost:3000`. In development mode, Vite proxies API requests to `http://localhost:5000`.
+
+**Using Docker Compose (full stack with PostgreSQL):**
 
 ```bash
 docker-compose up --build
 ```
 
-The API will be available at `http://localhost:8080` with a fully configured PostgreSQL database.
+- API available at `http://localhost:8080`
+- Frontend available at `http://localhost:3000`
+- PostgreSQL on port `5432`
 
 ### Running Tests
 
@@ -138,6 +190,14 @@ Obtain a token via `POST /api/auth/token`.
 ## Project Structure
 
 ```
+├── frontend/                 # React SPA (TypeScript, Vite, Tailwind CSS)
+│   ├── src/
+│   │   ├── pages/            # Login, Dashboard, Tasks, Users, Health
+│   │   ├── components/       # Shared UI components
+│   │   ├── contexts/         # AuthContext (JWT management)
+│   │   └── api/              # API client & TanStack Query hooks
+│   ├── Dockerfile            # Multi-stage: node build → nginx serve
+│   └── package.json
 ├── API/
 │   ├── Controllers/          # Thin API controllers
 │   └── Middleware/            # Exception handling, cross-cutting concerns
@@ -151,10 +211,10 @@ Obtain a token via `POST /api/auth/token`.
 ├── tests/
 │   └── Application.Tests/    # Integration tests with Testcontainers
 ├── docs/
-│   └── implementation-plans/ # Architecture decision records
+│   └── arc42/                # Architecture documentation (Arc42)
 ├── Program.cs                # Application bootstrap & middleware pipeline
 ├── docker-compose.yml        # Container orchestration
-├── Dockerfile                # Multi-stage build
+├── Dockerfile                # Multi-stage build (API)
 └── TodoApp.sln               # Solution file
 ```
 

--- a/docs/arc42/03-system-scope-and-context.md
+++ b/docs/arc42/03-system-scope-and-context.md
@@ -2,16 +2,18 @@
 
 ## Business Context
 
-The TodoApp API serves as the backend for task management. External actors interact with the system through its REST API.
+The TodoApp consists of a React SPA frontend and a .NET 8 API backend. Users interact with the system through the React application, which communicates with the API via REST/JSON over HTTP.
 
 ```mermaid
 graph TB
-    User([User / Client Application])
+    User([User])
+    SPA[React SPA<br/>TypeScript + Vite]
     API[TodoApp API<br/>.NET 8]
     DB[(PostgreSQL)]
     JWT[JWT Token Issuer<br/>Self-contained]
 
-    User -->|REST API calls| API
+    User -->|Browser| SPA
+    SPA -->|REST/JSON| API
     API -->|Read/Write data| DB
     API -->|Issue & validate tokens| JWT
 ```
@@ -20,7 +22,8 @@ graph TB
 
 | Interface         | Technology       | Purpose                                      |
 |-------------------|-----------------|----------------------------------------------|
-| REST API          | HTTP/JSON       | Primary interface for all client interactions |
+| React SPA         | HTTP/Browser    | Primary user interface (served via nginx)     |
+| REST API          | HTTP/JSON       | Backend interface consumed by the SPA         |
 | PostgreSQL        | TCP/5432        | Persistent data storage                      |
 | JWT Issuer        | Internal (HMAC) | Self-contained token generation and validation |
 | Health Endpoints  | HTTP            | `/health` and `/health/ready` for monitoring |
@@ -30,12 +33,13 @@ graph TB
 
 | Actor              | Description                                              |
 |--------------------|----------------------------------------------------------|
+| End User           | Interacts with the React SPA in a browser                |
 | API Consumer       | Any HTTP client (SPA, mobile app, CLI) calling the API   |
 | Authenticated User | A registered user who has obtained a JWT token           |
 | Operations Team    | Monitors health checks and application logs              |
 
 ## System Boundary
 
-The system boundary encompasses the ASP.NET Core application and its directly managed database. JWT token issuance is self-contained (symmetric key signing within the application). No external identity provider is currently integrated.
+The system boundary encompasses the React SPA, the ASP.NET Core API, and the managed PostgreSQL database. The SPA is the primary user-facing interface, communicating with the API exclusively through versioned REST endpoints. JWT token issuance is self-contained (symmetric key signing within the application). No external identity provider is currently integrated.
 
-All API endpoints are versioned (default: `v1`) and protected by rate limiting. Authentication is required for task and comment operations.
+All API endpoints are versioned (default: `v1`) and protected by rate limiting. Authentication is required for task and comment operations. The SPA manages JWT tokens via an AuthContext and includes them as Bearer tokens in all authenticated requests.

--- a/docs/arc42/05-building-block-view.md
+++ b/docs/arc42/05-building-block-view.md
@@ -1,9 +1,24 @@
 # 5. Building Block View
 
+## Level 0 — System Overview
+
+```mermaid
+graph LR
+    Browser([Browser]) -->|HTTP :3000| Frontend[React SPA<br/>TypeScript + Vite + Tailwind]
+    Frontend -->|REST/JSON| API[TodoApp API<br/>.NET 8]
+    API -->|TCP :5432| DB[(PostgreSQL)]
+```
+
 ## Level 1 — System Layers
 
 ```mermaid
 graph TB
+    subgraph "Frontend (React SPA)"
+        Pages[Pages<br/>Login, Dashboard, Tasks, Users, Health]
+        AuthCtx[AuthContext<br/>JWT Token Management]
+        TQ[TanStack Query<br/>Server State & Caching]
+    end
+
     subgraph "API Layer"
         Controllers[Controllers<br/>AuthController, TasksController,<br/>UsersController, CommentsController]
         Middleware[Middleware<br/>ExceptionHandlingMiddleware]
@@ -24,6 +39,9 @@ graph TB
         DB[(PostgreSQL)]
     end
 
+    Pages --> AuthCtx
+    Pages --> TQ
+    TQ -->|REST/JSON| Controllers
     Controllers --> TSK
     Controllers --> USR
     Controllers --> CMT

--- a/docs/arc42/06-runtime-view.md
+++ b/docs/arc42/06-runtime-view.md
@@ -71,3 +71,30 @@ sequenceDiagram
 ## Error Handling Flow
 
 When an unhandled exception occurs, the `ExceptionHandlingMiddleware` catches it, logs it via Serilog, maps it to an appropriate HTTP status code, and returns a RFC 7807 `ProblemDetails` JSON response.
+
+## Scenario 4 — Frontend Login Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ReactSPA
+    participant AuthContext
+    participant API
+    participant PostgreSQL
+
+    User->>ReactSPA: Enter username on Login page
+    ReactSPA->>API: POST /api/auth/token {username}
+    API->>PostgreSQL: SELECT user WHERE username = ?
+    PostgreSQL-->>API: User entity
+    API->>API: Generate JWT (HMAC-SHA256)
+    API-->>ReactSPA: 200 OK {token, expiresAt}
+    ReactSPA->>AuthContext: Store JWT in memory
+    AuthContext-->>ReactSPA: Authenticated state
+
+    Note over ReactSPA,API: Subsequent requests include Bearer token
+
+    User->>ReactSPA: Navigate to Tasks page
+    ReactSPA->>API: GET /api/v1/tasks [Authorization: Bearer <token>]
+    API-->>ReactSPA: 200 OK [tasks]
+    ReactSPA->>User: Render task list
+```

--- a/docs/arc42/07-deployment-view.md
+++ b/docs/arc42/07-deployment-view.md
@@ -5,29 +5,42 @@
 ```mermaid
 graph LR
     subgraph "Docker Compose Environment"
+        FE[frontend container<br/>nginx:alpine<br/>Port 3000]
         API[api container<br/>.NET 8 Runtime<br/>Port 8080]
         PG[postgres container<br/>PostgreSQL 16 Alpine<br/>Port 5432]
         VOL[(postgres_data<br/>Named Volume)]
     end
 
-    Client([Client]) -->|HTTP :8080| API
+    Client([Browser]) -->|HTTP :3000| FE
+    FE -->|Proxy /api| API
+    Client -->|HTTP :8080| API
     API -->|TCP :5432| PG
     PG --- VOL
 ```
 
 ## Docker Compose Services
 
-| Service    | Image                              | Port  | Purpose                    |
-|-----------|-------------------------------------|-------|----------------------------|
-| `api`      | Custom (multi-stage Dockerfile)    | 8080  | ASP.NET Core application   |
-| `postgres` | `postgres:16-alpine`               | 5432  | Persistent data storage    |
+| Service    | Image                              | Port  | Purpose                              |
+|-----------|-------------------------------------|-------|--------------------------------------|
+| `frontend` | Custom (node build → nginx:alpine) | 3000  | React SPA + API reverse proxy        |
+| `api`      | Custom (multi-stage Dockerfile)    | 8080  | ASP.NET Core application             |
+| `postgres` | `postgres:16-alpine`               | 5432  | Persistent data storage              |
 
 ## Dockerfile Strategy
 
-The application uses a multi-stage Docker build:
+### API
+
+The API uses a multi-stage Docker build:
 
 1. **Build stage** (`dotnet/sdk:8.0`) — Restores packages, compiles, and publishes the application
 2. **Runtime stage** (`dotnet/aspnet:8.0`) — Minimal runtime image with only the published output
+
+### Frontend
+
+The frontend uses a multi-stage Docker build:
+
+1. **Build stage** (`node:20-alpine`) — Installs dependencies and builds the production bundle with Vite
+2. **Serve stage** (`nginx:alpine`) — Serves static files and proxies `/api` requests to the API container
 
 ## Environment Variables
 
@@ -50,6 +63,7 @@ The application uses a multi-stage Docker build:
 
 ```bash
 docker compose up --build
+# Frontend available at http://localhost:3000
 # API available at http://localhost:8080
 # Swagger UI at http://localhost:8080/swagger
 ```

--- a/docs/arc42/08-cross-cutting-concepts.md
+++ b/docs/arc42/08-cross-cutting-concepts.md
@@ -53,3 +53,29 @@ Configured via `Asp.Versioning` with three simultaneous version readers:
 - Header (`X-Api-Version: 1.0`)
 
 Default version is `1.0`, assumed when unspecified.
+
+## Frontend Architecture
+
+The React SPA implements several cross-cutting concerns:
+
+### JWT Token Management
+
+The `AuthContext` provides centralised authentication state management:
+- Stores the JWT token in memory (not localStorage) for security
+- Automatically includes the `Authorization: Bearer <token>` header on all authenticated API requests
+- Handles token expiry and redirects to the login page when a 401 response is received
+
+### Server State (TanStack Query)
+
+TanStack Query manages all server state with:
+- Automatic background refetching for stale data
+- Optimistic updates for responsive UI
+- Request deduplication (multiple components requesting the same data trigger a single API call)
+- Cache invalidation on mutations
+
+### Styling (Tailwind CSS)
+
+Tailwind CSS provides a consistent design language:
+- Utility-first approach eliminates custom CSS sprawl
+- Responsive design built into the class system
+- Consistent spacing, colour, and typography scales across all pages


### PR DESCRIPTION
## Summary

Updates the README and Arc42 architecture documentation to reflect the React frontend that was added to the application.

### Changes

**README.md:**
- Added "Frontend" section with tech stack, pages, and running instructions
- Updated architecture diagram to show React SPA layer
- Added React, TypeScript, Vite, Tailwind CSS, TanStack Query to the tech stack table
- Updated project structure to include `frontend/` folder
- Updated running instructions with frontend dev server and docker-compose (port 3000)

**Arc42 Documentation:**
- **03 System Scope & Context** — Updated business context diagram and interfaces to show React SPA as the user-facing layer
- **05 Building Block View** — Added Level 0 system overview and updated Level 1 to include frontend components
- **06 Runtime View** — Added Scenario 4: Frontend Login Flow sequence diagram
- **07 Deployment View** — Added frontend container (nginx:alpine) to deployment topology and Docker Compose services table
- **08 Cross-cutting Concepts** — Added "Frontend Architecture" section covering JWT token management, TanStack Query server state, and Tailwind CSS styling