### PR TITLE
ci: add Playwright E2E tests to pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,100 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore .NET dependencies
+        run: dotnet restore
+
+      - name: Build .NET API
+        run: dotnet build --no-restore
+
+      - name: Start API server
+        run: dotnet run --no-build --urls http://localhost:5000 &
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install chromium --with-deps
+
+      - name: Start Vite dev server
+        working-directory: frontend
+        run: npm run dev &
+
+      - name: Wait for API server
+        run: |
+          echo "Waiting for API server..."
+          for i in $(seq 1 30); do
+            if curl -s http://localhost:5000/health > /dev/null 2>&1; then
+              echo "API server is ready"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "API server failed to start"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Wait for Vite dev server
+        run: |
+          echo "Waiting for Vite dev server..."
+          for i in $(seq 1 30); do
+            if curl -s http://localhost:5173 > /dev/null 2>&1; then
+              echo "Vite dev server is ready"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "Vite dev server failed to start"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -154,6 +154,40 @@ dotnet test
 
 Tests use **Testcontainers** to spin up isolated PostgreSQL instances, ensuring reliable integration testing without external dependencies.
 
+### E2E Tests (Playwright)
+
+The frontend includes end-to-end tests using [Playwright](https://playwright.dev/) that verify full user flows against the running application.
+
+**Using the helper script (Windows):**
+
+```powershell
+# First run — installs deps and Playwright browsers
+./scripts/run-e2e.ps1 -Install
+
+# Subsequent runs
+./scripts/run-e2e.ps1
+
+# Run with browser visible
+./scripts/run-e2e.ps1 -Headed
+```
+
+**Manual steps:**
+
+```bash
+# Terminal 1 — start the API
+dotnet run --urls http://localhost:5000
+
+# Terminal 2 — start the frontend
+cd frontend
+npm run dev
+
+# Terminal 3 — run E2E tests
+cd frontend
+npx playwright test
+```
+
+E2E tests also run automatically in CI on every pull request via the `E2E Tests` workflow.
+
 ---
 
 ## API Documentation

--- a/scripts/run-e2e.ps1
+++ b/scripts/run-e2e.ps1
@@ -1,0 +1,101 @@
+# Run Playwright E2E tests locally
+# Prerequisites: .NET 8 SDK, Node.js 20+, npm
+
+param(
+    [switch]$Install,
+    [switch]$Headed
+)
+
+$ErrorActionPreference = "Stop"
+$rootDir = Split-Path -Parent $PSScriptRoot
+$frontendDir = Join-Path $rootDir "frontend"
+
+Write-Host "=== E2E Test Runner ===" -ForegroundColor Cyan
+
+# Install dependencies if requested
+if ($Install) {
+    Write-Host "`nInstalling frontend dependencies..." -ForegroundColor Yellow
+    Push-Location $frontendDir
+    npm ci
+    npx playwright install chromium --with-deps
+    Pop-Location
+}
+
+# Build the .NET API
+Write-Host "`nBuilding .NET API..." -ForegroundColor Yellow
+Push-Location $rootDir
+dotnet build --quiet
+Pop-Location
+
+# Start the API server in the background
+Write-Host "`nStarting API server on http://localhost:5000..." -ForegroundColor Yellow
+$apiProcess = Start-Process -FilePath "dotnet" -ArgumentList "run", "--no-build", "--urls", "http://localhost:5000" -WorkingDirectory $rootDir -PassThru -NoNewWindow
+
+# Start the Vite dev server in the background
+Write-Host "Starting Vite dev server on http://localhost:5173..." -ForegroundColor Yellow
+$viteProcess = Start-Process -FilePath "npm" -ArgumentList "run", "dev" -WorkingDirectory $frontendDir -PassThru -NoNewWindow
+
+# Wait for servers to be ready
+Write-Host "`nWaiting for servers..." -ForegroundColor Yellow
+
+$maxRetries = 30
+for ($i = 1; $i -le $maxRetries; $i++) {
+    try {
+        $null = Invoke-WebRequest -Uri "http://localhost:5000/health" -UseBasicParsing -TimeoutSec 2
+        Write-Host "  API server is ready" -ForegroundColor Green
+        break
+    } catch {
+        if ($i -eq $maxRetries) {
+            Write-Host "  API server failed to start" -ForegroundColor Red
+            Stop-Process -Id $apiProcess.Id -ErrorAction SilentlyContinue
+            Stop-Process -Id $viteProcess.Id -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Start-Sleep -Seconds 2
+    }
+}
+
+for ($i = 1; $i -le $maxRetries; $i++) {
+    try {
+        $null = Invoke-WebRequest -Uri "http://localhost:5173" -UseBasicParsing -TimeoutSec 2
+        Write-Host "  Vite dev server is ready" -ForegroundColor Green
+        break
+    } catch {
+        if ($i -eq $maxRetries) {
+            Write-Host "  Vite dev server failed to start" -ForegroundColor Red
+            Stop-Process -Id $apiProcess.Id -ErrorAction SilentlyContinue
+            Stop-Process -Id $viteProcess.Id -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Start-Sleep -Seconds 2
+    }
+}
+
+# Run Playwright tests
+Write-Host "`nRunning Playwright E2E tests..." -ForegroundColor Cyan
+Push-Location $frontendDir
+
+$playwrightArgs = "playwright", "test"
+if ($Headed) {
+    $playwrightArgs += "--headed"
+}
+
+try {
+    & npx @playwrightArgs
+    $testExitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+    # Clean up background processes
+    Write-Host "`nStopping servers..." -ForegroundColor Yellow
+    Stop-Process -Id $apiProcess.Id -ErrorAction SilentlyContinue
+    Stop-Process -Id $viteProcess.Id -ErrorAction SilentlyContinue
+}
+
+if ($testExitCode -eq 0) {
+    Write-Host "`n=== All E2E tests passed! ===" -ForegroundColor Green
+} else {
+    Write-Host "`n=== E2E tests failed (exit code: $testExitCode) ===" -ForegroundColor Red
+    Write-Host "View the report: npx playwright show-report (from frontend/)" -ForegroundColor Yellow
+}
+
+exit $testExitCode


### PR DESCRIPTION
## Summary

Adds Playwright end-to-end tests to the CI pipeline, running automatically on every pull request to `main`.

## Changes

### `.github/workflows/e2e.yml`
- Triggers on `pull_request` to `main`
- Sets up .NET 8 and Node.js 20 with caching
- Builds and starts the API server in background
- Installs frontend deps and Playwright Chromium browser
- Starts Vite dev server in background
- Waits for both servers with retry loops
- Runs Playwright tests
- Uploads HTML report as artifact (on any outcome)

### `scripts/run-e2e.ps1`
- Local helper script for running E2E tests on Windows
- Supports `-Install` flag for first-time setup
- Supports `-Headed` flag for visible browser execution
- Manages API and Vite server lifecycle automatically

### `README.md`
- Added E2E testing section with usage instructions for both local and CI execution