### PR TITLE
feat: add Kubernetes manifests and Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Each feature folder contains:
 | Swashbuckle | 6.9.0 | Swagger/OpenAPI documentation |
 | JWT Bearer | 8.0.0 | Authentication |
 | Asp.Versioning | 8.1.0 | API versioning |
-| Docker Compose | — | Container orchestration |
+| Docker Compose | — | Container orchestration (development) |
+| Kubernetes | — | Container orchestration (production) |
+| Helm | 3.x | Kubernetes package management |
 | Testcontainers | 3.6.0 | Integration test infrastructure |
 | FluentAssertions | 6.12.0 | Expressive test assertions |
 | NSubstitute | 5.1.0 | Mocking framework |
@@ -208,15 +210,87 @@ Obtain a token via `POST /api/auth/token`.
 ├── Domain/
 │   └── Entities/             # Domain models (TaskItem, User, Comment)
 ├── Infrastructure/           # AppDbContext, entity configurations
+├── k8s/                      # Raw Kubernetes manifests (reference)
+├── charts/
+│   └── todoapp/              # Helm chart for production deployment
 ├── tests/
 │   └── Application.Tests/    # Integration tests with Testcontainers
 ├── docs/
 │   └── arc42/                # Architecture documentation (Arc42)
+├── scripts/                  # Deployment and utility scripts
 ├── Program.cs                # Application bootstrap & middleware pipeline
-├── docker-compose.yml        # Container orchestration
+├── docker-compose.yml        # Container orchestration (development)
 ├── Dockerfile                # Multi-stage build (API)
 └── TodoApp.sln               # Solution file
 ```
+
+---
+
+## Kubernetes Deployment
+
+The application includes Kubernetes manifests and a Helm chart for production-grade container orchestration.
+
+### Prerequisites
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) configured for your cluster
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- A running Kubernetes cluster (local: [minikube](https://minikube.sigs.k8s.io/) / [kind](https://kind.sigs.k8s.io/), cloud: AKS/EKS/GKE)
+- [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) installed in the cluster
+
+### Quick Deploy with Helm
+
+```powershell
+# Deploy using the provided script
+.\scripts\deploy-k8s.ps1
+
+# Or manually with Helm
+helm upgrade --install todoapp ./charts/todoapp --namespace todoapp --create-namespace
+```
+
+### Custom Values
+
+Override defaults by passing a values file:
+
+```powershell
+.\scripts\deploy-k8s.ps1 -ValuesFile "my-values.yaml"
+
+# Or with Helm directly
+helm upgrade --install todoapp ./charts/todoapp -n todoapp --values my-values.yaml
+```
+
+Example custom values:
+
+```yaml
+api:
+  replicaCount: 3
+  image:
+    repository: myregistry.azurecr.io/todoapp-api
+    tag: "v1.2.0"
+ingress:
+  host: todoapp.mycompany.com
+secrets:
+  connectionString: "Host=prod-db;Port=5432;Database=todoapp;Username=app;Password=secure-pw"
+```
+
+### Raw Manifests (kubectl)
+
+For environments without Helm, apply the raw manifests directly:
+
+```bash
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/
+```
+
+### Architecture
+
+| Component | Type | Access |
+|-----------|------|--------|
+| API | Deployment (2 replicas) | ClusterIP → Ingress `/api` |
+| Frontend | Deployment (2 replicas) | ClusterIP → Ingress `/` |
+| PostgreSQL | StatefulSet + PVC | ClusterIP (internal) |
+| Redis | Deployment | ClusterIP (internal) |
+
+> 📖 See [ADR 013](docs/ADRs/013-kubernetes-orchestration.md) for the full decision record.
 
 ---
 
@@ -237,6 +311,7 @@ Obtain a token via `POST /api/auth/token`.
 | **CORS** | Configurable cross-origin resource sharing |
 | **OpenAPI/Swagger** | Auto-generated, interactive API documentation |
 | **Containerisation** | Docker multi-stage build with Compose orchestration |
+| **Kubernetes** | Helm chart with StatefulSets, Deployments, Ingress, and health probes |
 | **Integration Testing** | Testcontainers for disposable database instances |
 
 ---

--- a/charts/todoapp/Chart.yaml
+++ b/charts/todoapp/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: todoapp
+description: A Helm chart for the TodoApp - Enterprise .NET Todo Application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - todoapp
+  - dotnet
+  - aspnetcore
+  - react
+home: https://github.com/JurreBrandsenInfoSupport/modern-copilot-.NET-Todo-app
+maintainers:
+  - name: TodoApp Team

--- a/charts/todoapp/templates/NOTES.txt
+++ b/charts/todoapp/templates/NOTES.txt
@@ -1,0 +1,27 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your TodoApp has been deployed to the {{ .Release.Namespace }} namespace.
+
+{{- if .Values.ingress.enabled }}
+
+The application is accessible via ingress:
+  http://{{ .Values.ingress.host }}
+
+Make sure your ingress controller is running and DNS/hosts file is configured:
+  echo "$(kubectl get ingress {{ include "todoapp.fullname" . }}-ingress -n {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}') {{ .Values.ingress.host }}" | sudo tee -a /etc/hosts
+{{- else }}
+
+To access the application, use port-forwarding:
+
+  # Frontend
+  kubectl port-forward svc/{{ include "todoapp.fullname" . }}-frontend 3000:80 -n {{ .Release.Namespace }}
+
+  # API
+  kubectl port-forward svc/{{ include "todoapp.fullname" . }}-api 8080:80 -n {{ .Release.Namespace }}
+{{- end }}
+
+To check the status of your deployment:
+  kubectl get pods -n {{ .Release.Namespace }}
+
+To view API health:
+  kubectl exec -it deploy/{{ include "todoapp.fullname" . }}-api -n {{ .Release.Namespace }} -- curl -s http://localhost:8080/health

--- a/charts/todoapp/templates/_helpers.tpl
+++ b/charts/todoapp/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Common labels for all resources
+*/}}
+{{- define "todoapp.labels" -}}
+app.kubernetes.io/name: {{ include "todoapp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "todoapp.chart" . }}
+{{- end }}
+
+{{/*
+Selector labels for a given component
+*/}}
+{{- define "todoapp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "todoapp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Chart name
+*/}}
+{{- define "todoapp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Full name (release + chart)
+*/}}
+{{- define "todoapp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value
+*/}}
+{{- define "todoapp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/todoapp/templates/api-deployment.yaml
+++ b/charts/todoapp/templates/api-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "todoapp.fullname" . }}-api
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "todoapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "todoapp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.api.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "todoapp.fullname" . }}-config
+            - secretRef:
+                name: {{ include "todoapp.fullname" . }}-secrets
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.api.service.targetPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: {{ .Values.api.service.targetPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/charts/todoapp/templates/api-service.yaml
+++ b/charts/todoapp/templates/api-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "todoapp.fullname" . }}-api
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.api.service.type }}
+  selector:
+    {{- include "todoapp.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  ports:
+    - port: {{ .Values.api.service.port }}
+      targetPort: {{ .Values.api.service.targetPort }}
+      protocol: TCP
+      name: http

--- a/charts/todoapp/templates/configmap.yaml
+++ b/charts/todoapp/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "todoapp.fullname" . }}-config
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+data:
+  ASPNETCORE_ENVIRONMENT: {{ .Values.api.env.aspnetcoreEnvironment | quote }}
+  ASPNETCORE_URLS: "http://+:8080"

--- a/charts/todoapp/templates/frontend-deployment.yaml
+++ b/charts/todoapp/templates/frontend-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "todoapp.fullname" . }}-frontend
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "todoapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "todoapp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.frontend.service.targetPort }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.service.targetPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.service.targetPort }}
+            initialDelaySeconds: 3
+            periodSeconds: 10

--- a/charts/todoapp/templates/frontend-service.yaml
+++ b/charts/todoapp/templates/frontend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "todoapp.fullname" . }}-frontend
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    {{- include "todoapp.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.service.targetPort }}
+      protocol: TCP
+      name: http

--- a/charts/todoapp/templates/ingress.yaml
+++ b/charts/todoapp/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "todoapp.fullname" . }}-ingress
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "todoapp.fullname" . }}-api
+                port:
+                  number: {{ .Values.api.service.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "todoapp.fullname" . }}-frontend
+                port:
+                  number: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/charts/todoapp/templates/postgres-service.yaml
+++ b/charts/todoapp/templates/postgres-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "todoapp.fullname" . }}-postgres
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "todoapp.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: 5432
+      protocol: TCP
+      name: postgresql
+{{- end }}

--- a/charts/todoapp/templates/postgres-statefulset.yaml
+++ b/charts/todoapp/templates/postgres-statefulset.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "todoapp.fullname" . }}-postgres
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "todoapp.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "todoapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "todoapp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.credentials.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.credentials.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "todoapp.fullname" . }}-secrets
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.credentials.username }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.credentials.username }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.postgres.storage.storageClassName }}
+        storageClassName: {{ .Values.postgres.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage.size }}
+{{- end }}

--- a/charts/todoapp/templates/redis-deployment.yaml
+++ b/charts/todoapp/templates/redis-deployment.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "todoapp.fullname" . }}-redis
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "todoapp.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "todoapp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+{{- end }}

--- a/charts/todoapp/templates/redis-service.yaml
+++ b/charts/todoapp/templates/redis-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "todoapp.fullname" . }}-redis
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "todoapp.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+{{- end }}

--- a/charts/todoapp/templates/secret.yaml
+++ b/charts/todoapp/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "todoapp.fullname" . }}-secrets
+  labels:
+    {{- include "todoapp.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ConnectionStrings__DefaultConnection: {{ .Values.secrets.connectionString | b64enc | quote }}
+  Jwt__Key: {{ .Values.secrets.jwtKey | b64enc | quote }}
+  POSTGRES_PASSWORD: {{ .Values.postgres.credentials.password | b64enc | quote }}

--- a/charts/todoapp/values.yaml
+++ b/charts/todoapp/values.yaml
@@ -1,0 +1,103 @@
+# Default values for todoapp Helm chart
+
+# -- Global settings
+nameOverride: ""
+fullnameOverride: ""
+
+# -- API configuration
+api:
+  replicaCount: 2
+  image:
+    repository: todoapp-api
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    aspnetcoreEnvironment: "Production"
+
+# -- Frontend configuration
+frontend:
+  replicaCount: 2
+  image:
+    repository: todoapp-frontend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+# -- PostgreSQL configuration
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    port: 5432
+  storage:
+    size: 5Gi
+    storageClassName: ""
+  credentials:
+    database: todoapp
+    username: todoapp
+    # Password is stored in secrets - override via --set or values file
+    password: "changeme"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# -- Redis configuration
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+# -- Ingress configuration
+ingress:
+  enabled: true
+  className: nginx
+  host: todoapp.local
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  tls: []
+
+# -- Secrets
+secrets:
+  # Connection string for PostgreSQL
+  connectionString: "Host=postgres;Port=5432;Database=todoapp;Username=todoapp;Password=changeme"
+  # JWT signing key (minimum 32 characters)
+  jwtKey: "your-super-secret-jwt-key-min-32-chars!"

--- a/docs/ADRs/013-kubernetes-orchestration.md
+++ b/docs/ADRs/013-kubernetes-orchestration.md
@@ -1,0 +1,71 @@
+# ADR 013: Kubernetes Orchestration
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-03
+
+## Context
+
+The TodoApp has outgrown simple Docker Compose deployments for production environments. We need a container orchestration platform that provides:
+
+- Automated scaling and self-healing
+- Service discovery and load balancing
+- Rolling updates with zero-downtime deployments
+- Declarative infrastructure management
+- Secrets and configuration management
+- Health monitoring and readiness checks
+
+The application already has Docker images for the API and frontend, health check endpoints (`/health` and `/health/ready`), and structured logging — all of which are prerequisites for Kubernetes deployment.
+
+## Decision
+
+We will adopt **Kubernetes** as the container orchestration platform with **Helm** as the package manager for templated deployments.
+
+### Deployment Strategy
+
+1. **Raw manifests** (`k8s/`) serve as a reference implementation and for simple `kubectl apply` workflows.
+2. **Helm chart** (`charts/todoapp/`) provides a configurable, repeatable deployment mechanism with environment-specific values files.
+
+### Architecture on Kubernetes
+
+| Component | Kind | Replicas | Notes |
+|-----------|------|----------|-------|
+| API | Deployment | 2 | Stateless, horizontally scalable |
+| Frontend | Deployment | 2 | Static nginx, horizontally scalable |
+| PostgreSQL | StatefulSet | 1 | Persistent volume for data durability |
+| Redis | Deployment | 1 | Caching layer, ephemeral |
+| Ingress | Ingress (nginx) | — | Path-based routing: `/api` → API, `/` → Frontend |
+
+### Key Design Choices
+
+- **StatefulSet for PostgreSQL**: Ensures stable network identity and persistent storage via PVC.
+- **ClusterIP services**: Internal-only communication; external access via Ingress controller.
+- **Resource limits on all containers**: Prevents noisy-neighbour issues and enables cluster autoscaling.
+- **Liveness and readiness probes**: Leverages existing `/health` and `/health/ready` endpoints for automated recovery.
+- **Secrets via Kubernetes Secrets**: Base64-encoded with guidance to use external secret stores (e.g., Azure Key Vault, HashiCorp Vault) in production.
+
+## Consequences
+
+### Positive
+
+- Production-ready deployment with automated scaling, health management, and rolling updates.
+- Helm chart enables consistent deployments across environments (dev, staging, production).
+- Infrastructure-as-code approach with version-controlled manifests.
+- Built-in service discovery eliminates manual networking configuration.
+
+### Negative
+
+- Increased operational complexity compared to Docker Compose.
+- Requires a running Kubernetes cluster (local: minikube/kind, cloud: AKS/EKS/GKE).
+- Team needs Kubernetes and Helm knowledge for day-to-day operations.
+- PostgreSQL in Kubernetes is suitable for development/staging; production may warrant a managed database service.
+
+### Mitigations
+
+- Docker Compose remains available for local development.
+- Deploy script (`scripts/deploy-k8s.ps1`) simplifies the deployment workflow.
+- Comprehensive documentation in README covers setup and common operations.

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: todoapp-api
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: todoapp
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: todoapp
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: api
+          image: todoapp-api:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: todoapp-config
+            - secretRef:
+                name: todoapp-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: todoapp-api
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: api
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: todoapp-config
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+data:
+  ASPNETCORE_ENVIRONMENT: "Production"
+  ASPNETCORE_URLS: "http://+:8080"
+  Serilog__MinimumLevel__Default: "Information"

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: todoapp-frontend
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: todoapp
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: todoapp
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: todoapp-frontend:latest
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 10

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: todoapp-frontend
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: todoapp-ingress
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: todoapp.local
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: todoapp-api
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: todoapp-frontend
+                port:
+                  number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/managed-by: kubectl

--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgresql

--- a/k8s/postgres-statefulset.yaml
+++ b/k8s/postgres-statefulset.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: todoapp
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: todoapp
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: todoapp
+            - name: POSTGRES_USER
+              value: todoapp
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: todoapp-secrets
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - todoapp
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - todoapp
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/redis-deployment.yaml
+++ b/k8s/redis-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: todoapp
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: todoapp
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/k8s/redis-service.yaml
+++ b/k8s/redis-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: todoapp
+    app.kubernetes.io/component: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: todoapp-secrets
+  namespace: todoapp
+  labels:
+    app.kubernetes.io/name: todoapp
+type: Opaque
+data:
+  # Base64-encoded placeholders - replace with real values before deploying
+  # echo -n 'Host=postgres;Port=5432;Database=todoapp;Username=todoapp;Password=changeme' | base64
+  ConnectionStrings__DefaultConnection: SG9zdD1wb3N0Z3JlcztQb3J0PTU0MzI7RGF0YWJhc2U9dG9kb2FwcDtVc2VybmFtZT10b2RvYXBwO1Bhc3N3b3JkPWNoYW5nZW1l
+  # echo -n 'your-super-secret-jwt-key-min-32-chars!' | base64
+  Jwt__Key: eW91ci1zdXBlci1zZWNyZXQtand0LWtleS1taW4tMzItY2hhcnMh
+  # echo -n 'changeme' | base64
+  POSTGRES_PASSWORD: Y2hhbmdlbWU=

--- a/scripts/deploy-k8s.ps1
+++ b/scripts/deploy-k8s.ps1
@@ -1,0 +1,75 @@
+# Deploy TodoApp to Kubernetes using Helm
+# Usage: .\scripts\deploy-k8s.ps1 [-Namespace todoapp] [-ReleaseName todoapp] [-ValuesFile ""]
+
+param(
+    [string]$Namespace = "todoapp",
+    [string]$ReleaseName = "todoapp",
+    [string]$ValuesFile = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Deploying TodoApp to Kubernetes..." -ForegroundColor Cyan
+Write-Host "  Namespace:    $Namespace" -ForegroundColor Gray
+Write-Host "  Release:      $ReleaseName" -ForegroundColor Gray
+
+# Check prerequisites
+$helm = Get-Command helm -ErrorAction SilentlyContinue
+if (-not $helm) {
+    Write-Error "Helm is not installed. Please install Helm: https://helm.sh/docs/intro/install/"
+    exit 1
+}
+
+$kubectl = Get-Command kubectl -ErrorAction SilentlyContinue
+if (-not $kubectl) {
+    Write-Error "kubectl is not installed. Please install kubectl: https://kubernetes.io/docs/tasks/tools/"
+    exit 1
+}
+
+# Verify cluster connectivity
+Write-Host "`nVerifying cluster connectivity..." -ForegroundColor Yellow
+kubectl cluster-info | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Cannot connect to Kubernetes cluster. Please check your kubeconfig."
+    exit 1
+}
+Write-Host "  Cluster connection verified." -ForegroundColor Green
+
+# Create namespace if it doesn't exist
+$nsExists = kubectl get namespace $Namespace 2>$null
+if (-not $nsExists) {
+    Write-Host "`nCreating namespace '$Namespace'..." -ForegroundColor Yellow
+    kubectl create namespace $Namespace
+}
+
+# Build Helm install command
+$chartPath = Join-Path $PSScriptRoot "..\charts\todoapp"
+$helmArgs = @(
+    "upgrade", "--install",
+    $ReleaseName,
+    $chartPath,
+    "--namespace", $Namespace,
+    "--create-namespace",
+    "--wait",
+    "--timeout", "5m"
+)
+
+if ($ValuesFile -and (Test-Path $ValuesFile)) {
+    $helmArgs += @("--values", $ValuesFile)
+    Write-Host "  Values file:  $ValuesFile" -ForegroundColor Gray
+}
+
+# Deploy
+Write-Host "`nRunning Helm install/upgrade..." -ForegroundColor Yellow
+& helm @helmArgs
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "`nDeployment successful!" -ForegroundColor Green
+    Write-Host "`nPod status:" -ForegroundColor Cyan
+    kubectl get pods -n $Namespace
+    Write-Host "`nServices:" -ForegroundColor Cyan
+    kubectl get svc -n $Namespace
+} else {
+    Write-Error "Helm deployment failed. Check the logs above for details."
+    exit 1
+}


### PR DESCRIPTION
## Summary

Adds production-ready Kubernetes deployment support with both raw manifests and a Helm chart.

## Changes

### Raw Kubernetes Manifests (`k8s/`)
Reference manifests for direct `kubectl apply` workflows:
- `namespace.yaml` — dedicated `todoapp` namespace
- `api-deployment.yaml` + `api-service.yaml` — API with health probes, 2 replicas
- `frontend-deployment.yaml` + `frontend-service.yaml` — nginx frontend, 2 replicas
- `postgres-statefulset.yaml` + `postgres-service.yaml` — StatefulSet with PVC for data persistence
- `redis-deployment.yaml` + `redis-service.yaml` — caching layer
- `ingress.yaml` — nginx ingress with path-based routing (`/api` → API, `/` → frontend)
- `configmap.yaml` + `secret.yaml` — configuration and credentials

### Helm Chart (`charts/todoapp/`)
Templated, configurable deployment:
- Configurable image tags, replicas, resource limits
- Ingress host and TLS settings
- Database credentials via values override
- Conditional Redis/PostgreSQL deployment
- Post-install notes with access instructions

### Scripts & Documentation
- `scripts/deploy-k8s.ps1` — simplified deployment script with prerequisite checks
- `docs/ADRs/013-kubernetes-orchestration.md` — architecture decision record
- Updated `README.md` with Kubernetes deployment section

## Deployment

```powershell
# Quick deploy
.\scripts\deploy-k8s.ps1

# Or with Helm directly
helm upgrade --install todoapp ./charts/todoapp --namespace todoapp --create-namespace
```

## Architecture

| Component | Kind | Replicas |
|-----------|------|----------|
| API | Deployment | 2 |
| Frontend | Deployment | 2 |
| PostgreSQL | StatefulSet | 1 |
| Redis | Deployment | 1 |
| Ingress | nginx Ingress | — |