### PR TITLE
feat: add Redis distributed caching layer

### DIFF
--- a/Application/Behaviours/CacheInvalidationBehavior.cs
+++ b/Application/Behaviours/CacheInvalidationBehavior.cs
@@ -1,0 +1,52 @@
+using MediatR;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace TodoApp.Application.Behaviours;
+
+/// <summary>
+/// Marker interface for commands that should invalidate cache entries on success.
+/// </summary>
+public interface ICacheInvalidatingCommand
+{
+    IEnumerable<string> CacheKeysToInvalidate { get; }
+}
+
+/// <summary>
+/// MediatR pipeline behavior that invalidates cache entries after a command succeeds.
+/// </summary>
+public class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<CacheInvalidationBehavior<TRequest, TResponse>> _logger;
+
+    public CacheInvalidationBehavior(IDistributedCache cache, ILogger<CacheInvalidationBehavior<TRequest, TResponse>> logger)
+    {
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        if (request is ICacheInvalidatingCommand invalidatingCommand)
+        {
+            foreach (var key in invalidatingCommand.CacheKeysToInvalidate)
+            {
+                try
+                {
+                    await _cache.RemoveAsync(key, cancellationToken);
+                    _logger.LogDebug("Cache invalidated for key: {CacheKey}", key);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to invalidate cache for key: {CacheKey}.", key);
+                }
+            }
+        }
+
+        return response;
+    }
+}

--- a/Application/Behaviours/CacheKeys.cs
+++ b/Application/Behaviours/CacheKeys.cs
@@ -1,0 +1,13 @@
+namespace TodoApp.Application.Behaviours;
+
+/// <summary>
+/// Centralised cache key constants to avoid magic strings.
+/// </summary>
+public static class CacheKeys
+{
+    public const string AllTasks = "tasks:all";
+    public const string AllUsers = "users:all";
+
+    public static string TasksByUser(int userId) => $"tasks:user:{userId}";
+    public static string CommentsByTask(int taskItemId) => $"comments:task:{taskItemId}";
+}

--- a/Application/Behaviours/CachingBehavior.cs
+++ b/Application/Behaviours/CachingBehavior.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using MediatR;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace TodoApp.Application.Behaviours;
+
+/// <summary>
+/// MediatR pipeline behavior that caches responses for queries implementing ICacheableQuery.
+/// </summary>
+public class CachingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<CachingBehavior<TRequest, TResponse>> _logger;
+
+    public CachingBehavior(IDistributedCache cache, ILogger<CachingBehavior<TRequest, TResponse>> logger)
+    {
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (request is not ICacheableQuery cacheableQuery)
+        {
+            return await next();
+        }
+
+        var cacheKey = cacheableQuery.CacheKey;
+
+        try
+        {
+            var cachedData = await _cache.GetStringAsync(cacheKey, cancellationToken);
+            if (cachedData != null)
+            {
+                _logger.LogDebug("Cache hit for key: {CacheKey}", cacheKey);
+                var result = JsonSerializer.Deserialize<TResponse>(cachedData);
+                if (result != null)
+                    return result;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read from cache for key: {CacheKey}. Proceeding without cache.", cacheKey);
+        }
+
+        var response = await next();
+
+        try
+        {
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = cacheableQuery.CacheDuration
+            };
+
+            var serialized = JsonSerializer.Serialize(response);
+            await _cache.SetStringAsync(cacheKey, serialized, options, cancellationToken);
+            _logger.LogDebug("Cache set for key: {CacheKey} with TTL: {CacheDuration}", cacheKey, cacheableQuery.CacheDuration);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write to cache for key: {CacheKey}.", cacheKey);
+        }
+
+        return response;
+    }
+}

--- a/Application/Behaviours/ICacheableQuery.cs
+++ b/Application/Behaviours/ICacheableQuery.cs
@@ -1,0 +1,12 @@
+using MediatR;
+
+namespace TodoApp.Application.Behaviours;
+
+/// <summary>
+/// Marker interface for queries that should be cached.
+/// </summary>
+public interface ICacheableQuery
+{
+    string CacheKey { get; }
+    TimeSpan CacheDuration { get; }
+}

--- a/Application/CMT003Comments/CommentsFeature.cs
+++ b/Application/CMT003Comments/CommentsFeature.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using TodoApp.Application.Behaviours;
 using TodoApp.Domain.Entities;
 using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
@@ -7,7 +8,10 @@ using TodoApp.Infrastructure;
 namespace TodoApp.Application.CMT003Comments
 {
     // Command to add a comment
-    public record AddCommentCommand(int TaskItemId, int UserId, string Text) : IRequest<Comment>;
+    public record AddCommentCommand(int TaskItemId, int UserId, string Text) : IRequest<Comment>, ICacheInvalidatingCommand
+    {
+        public IEnumerable<string> CacheKeysToInvalidate => new[] { CacheKeys.CommentsByTask(TaskItemId) };
+    }
 
     // Handler for adding a comment
     public class AddCommentHandler : IRequestHandler<AddCommentCommand, Comment>
@@ -41,7 +45,11 @@ namespace TodoApp.Application.CMT003Comments
     }
 
     // Query to get comments for a task
-    public record GetCommentsQuery(int TaskItemId) : IRequest<List<Comment>>;
+    public record GetCommentsQuery(int TaskItemId) : IRequest<List<Comment>>, ICacheableQuery
+    {
+        public string CacheKey => CacheKeys.CommentsByTask(TaskItemId);
+        public TimeSpan CacheDuration => TimeSpan.FromSeconds(30);
+    }
 
     // Handler for retrieving comments
     public class GetCommentsHandler : IRequestHandler<GetCommentsQuery, List<Comment>>

--- a/Application/TSK001Tasks/TasksFeature.cs
+++ b/Application/TSK001Tasks/TasksFeature.cs
@@ -1,12 +1,17 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using TodoApp.Application.Behaviours;
 using TodoApp.Domain.Entities;
 using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
 
 namespace TodoApp.Application.TSK001Tasks
 {
-    public record GetTasksByUserQuery(int UserId) : IRequest<List<TaskItem>>;
+    public record GetTasksByUserQuery(int UserId) : IRequest<List<TaskItem>>, ICacheableQuery
+    {
+        public string CacheKey => CacheKeys.TasksByUser(UserId);
+        public TimeSpan CacheDuration => TimeSpan.FromSeconds(30);
+    }
 
     public class GetTasksByUserHandler : IRequestHandler<GetTasksByUserQuery, List<TaskItem>>
     {
@@ -16,7 +21,14 @@ namespace TodoApp.Application.TSK001Tasks
         public async Task<List<TaskItem>> Handle(GetTasksByUserQuery request, CancellationToken cancellationToken)
             => await _db.Tasks.Where(t => t.UserId == request.UserId).ToListAsync(cancellationToken);
     }
-    public record CreateTaskCommand(string Title, int UserId) : IRequest<TaskItem>;
+    public record CreateTaskCommand(string Title, int UserId) : IRequest<TaskItem>, ICacheInvalidatingCommand
+    {
+        public IEnumerable<string> CacheKeysToInvalidate => new[]
+        {
+            CacheKeys.AllTasks,
+            CacheKeys.TasksByUser(UserId)
+        };
+    }
 
     public class CreateTaskHandler : IRequestHandler<CreateTaskCommand, TaskItem>
     {
@@ -36,7 +48,11 @@ namespace TodoApp.Application.TSK001Tasks
         }
     }
 
-    public record GetAllTasksQuery() : IRequest<List<TaskItem>>;
+    public record GetAllTasksQuery() : IRequest<List<TaskItem>>, ICacheableQuery
+    {
+        public string CacheKey => CacheKeys.AllTasks;
+        public TimeSpan CacheDuration => TimeSpan.FromSeconds(30);
+    }
 
     public class GetAllTasksHandler : IRequestHandler<GetAllTasksQuery, List<TaskItem>>
     {
@@ -47,7 +63,10 @@ namespace TodoApp.Application.TSK001Tasks
             => await _db.Tasks.ToListAsync(cancellationToken);
     }
 
-    public record CompleteTaskCommand(int TaskId) : IRequest<TaskItem>;
+    public record CompleteTaskCommand(int TaskId) : IRequest<TaskItem>, ICacheInvalidatingCommand
+    {
+        public IEnumerable<string> CacheKeysToInvalidate => new[] { CacheKeys.AllTasks };
+    }
 
     public class CompleteTaskHandler : IRequestHandler<CompleteTaskCommand, TaskItem>
     {

--- a/Application/USR002Users/UsersFeature.cs
+++ b/Application/USR002Users/UsersFeature.cs
@@ -1,12 +1,16 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using TodoApp.Application.Behaviours;
 using TodoApp.Domain.Entities;
 using TodoApp.Domain.Events;
 using TodoApp.Infrastructure;
 
 namespace TodoApp.Application.USR002Users
 {
-    public record RegisterUserCommand(string Username) : IRequest<User>;
+    public record RegisterUserCommand(string Username) : IRequest<User>, ICacheInvalidatingCommand
+    {
+        public IEnumerable<string> CacheKeysToInvalidate => new[] { CacheKeys.AllUsers };
+    }
 
     public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, User>
     {
@@ -24,7 +28,11 @@ namespace TodoApp.Application.USR002Users
         }
     }
 
-    public record GetAllUsersQuery() : IRequest<List<User>>;
+    public record GetAllUsersQuery() : IRequest<List<User>>, ICacheableQuery
+    {
+        public string CacheKey => CacheKeys.AllUsers;
+        public TimeSpan CacheDuration => TimeSpan.FromSeconds(30);
+    }
 
     public class GetAllUsersHandler : IRequestHandler<GetAllUsersQuery, List<User>>
     {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
 
     <!-- Test packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/Program.cs
+++ b/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi.Models;
 using Serilog;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using TodoApp.Application.Behaviours;
 using TodoApp.Infrastructure;
 using TodoApp.Application.TSK001Tasks;
 using TodoApp.Application.USR002Users;
@@ -27,9 +28,26 @@ builder.Services.AddDbContext<AppDbContext>(opt =>
     opt.UseInMemoryDatabase("TodoDb"));
 
 builder.Services.AddMediatR(typeof(Program).Assembly);
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>));
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CacheInvalidationBehavior<,>));
 builder.Services
     .AddTasksFeature()
     .AddUsersFeature();
+
+// Distributed cache: Redis in non-Testing environments, in-memory fallback for tests
+if (builder.Environment.IsEnvironment("Testing"))
+{
+    builder.Services.AddDistributedMemoryCache();
+}
+else
+{
+    var redisConnectionString = builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379";
+    builder.Services.AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = redisConnectionString;
+        options.InstanceName = "TodoApp:";
+    });
+}
 
 builder.Services.AddApiVersioning(options =>
 {
@@ -118,8 +136,17 @@ builder.Services.AddCors(options =>
     });
 });
 
-builder.Services.AddHealthChecks()
+var healthChecksBuilder = builder.Services.AddHealthChecks()
     .AddCheck("self", () => HealthCheckResult.Healthy("Application is running."));
+
+if (!builder.Environment.IsEnvironment("Testing"))
+{
+    healthChecksBuilder.AddRedis(
+        builder.Configuration.GetConnectionString("Redis") ?? "localhost:6379",
+        name: "redis",
+        failureStatus: HealthStatus.Degraded,
+        tags: new[] { "ready" });
+}
 
 builder.Services.AddRateLimiter(options =>
 {

--- a/TodoApp.csproj
+++ b/TodoApp.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Asp.Versioning.Http" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />

--- a/appsettings.json
+++ b/appsettings.json
@@ -32,6 +32,9 @@
     "Issuer": "TodoApp",
     "Audience": "TodoApp"
   },
+  "ConnectionStrings": {
+    "Redis": "localhost:6379"
+  },
   "Otel": {
     "Endpoint": "http://localhost:4317"
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,13 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
+      - redis
       - seq
     environment:
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=todoapp;Username=todoapp;Password=todoapp_dev
       - Serilog__WriteTo__2__Name=Seq
       - Serilog__WriteTo__2__Args__serverUrl=http://seq:5341
+      - ConnectionStrings__Redis=redis:6379
       - Otel__Endpoint=http://otel-collector:4317
 
   postgres:
@@ -30,6 +32,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
   seq:
     image: datalust/seq:latest
     ports:
@@ -40,3 +49,4 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:

--- a/docs/ADRs/012-redis-distributed-caching.md
+++ b/docs/ADRs/012-redis-distributed-caching.md
@@ -1,0 +1,56 @@
+# ADR 012: Redis Distributed Caching
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-03
+
+## Context
+
+The Todo application serves GET endpoints (`/api/v1/tasks`, `/api/v1/users`, `/api/v1/comments`) that repeatedly query the database for data that changes infrequently relative to the read frequency. As the application scales horizontally behind a load balancer, each instance would maintain its own isolated in-process cache, leading to inconsistent responses and wasted memory.
+
+We need a distributed caching layer that:
+- Reduces database load for frequently read data
+- Provides consistent cache state across multiple application instances
+- Supports cache invalidation when data changes
+- Degrades gracefully if the cache is unavailable
+
+## Decision
+
+We will introduce **Redis** as a distributed caching layer using `Microsoft.Extensions.Caching.StackExchangeRedis` and a MediatR pipeline behavior pattern.
+
+### Key design decisions:
+
+1. **MediatR Pipeline Behaviors**: Caching is implemented as cross-cutting concerns via `CachingBehavior<TRequest, TResponse>` and `CacheInvalidationBehavior<TRequest, TResponse>`, keeping feature code clean.
+
+2. **Marker Interfaces**: Queries opt-in to caching by implementing `ICacheableQuery` (providing cache key and TTL). Commands opt-in to invalidation by implementing `ICacheInvalidatingCommand` (providing keys to invalidate).
+
+3. **TTL Strategy**: 30-second absolute expiration for tasks/users/comments queries. Short enough to ensure reasonable freshness, long enough to meaningfully reduce database load.
+
+4. **Graceful Degradation**: Cache read/write failures are caught and logged as warnings. The application continues to function by falling back to the database.
+
+5. **Testing Environment**: Tests use `IDistributedMemoryCache` (in-memory) to avoid requiring a Redis instance, while production uses the Redis-backed implementation.
+
+6. **Health Check**: Redis is registered as a health check with `Degraded` failure status (not `Unhealthy`), reflecting that the app can function without it.
+
+## Consequences
+
+### Positive
+- Reduced database load for read-heavy workloads
+- Consistent caching across horizontally scaled instances
+- Clean separation of concerns via pipeline behaviors
+- No feature code changes needed to add caching to new queries
+- Graceful degradation ensures availability even if Redis is down
+
+### Negative
+- Additional infrastructure dependency (Redis)
+- Potential for stale reads within the TTL window
+- Increased operational complexity (monitoring, backup, memory management)
+- Serialisation/deserialisation overhead for cached objects
+
+### Risks
+- Cache stampede under high concurrency (mitigated by short TTL)
+- Memory pressure on Redis if cache keys grow unbounded (mitigated by absolute expiration)


### PR DESCRIPTION
## Summary

Adds Redis as a distributed caching layer for all GET query endpoints, implemented as MediatR pipeline behaviors for clean separation of concerns.

## Changes

### Infrastructure
- **docker-compose.yml**: Added `redis:7-alpine` service (port 6379) with persistent volume
- **appsettings.json**: Added `ConnectionStrings:Redis` configuration
- **Directory.Packages.props / TodoApp.csproj**: Added `Microsoft.Extensions.Caching.StackExchangeRedis` and `AspNetCore.HealthChecks.Redis`

### Caching Pipeline
- **`CachingBehavior<TRequest, TResponse>`**: MediatR pipeline that caches query responses using `IDistributedCache`. Gracefully degrades on Redis failures.
- **`CacheInvalidationBehavior<TRequest, TResponse>`**: Invalidates relevant cache keys when commands succeed.
- **`ICacheableQuery`**: Marker interface for queries (provides cache key + TTL)
- **`ICacheInvalidatingCommand`**: Marker interface for commands (provides keys to invalidate)
- **`CacheKeys`**: Centralised cache key constants

### Feature Updates
- `GetAllTasksQuery`, `GetTasksByUserQuery`, `GetAllUsersQuery`, `GetCommentsQuery` → implement `ICacheableQuery` (30s TTL)
- `CreateTaskCommand`, `CompleteTaskCommand`, `RegisterUserCommand`, `AddCommentCommand` → implement `ICacheInvalidatingCommand`

### Health & Testing
- Redis health check registered with `Degraded` failure status
- Testing environment uses in-memory distributed cache (no Redis dependency)
- All 25 existing tests pass unchanged

### Documentation
- ADR 012: Redis Distributed Caching

## Design Decisions
- **30s TTL**: Short enough for freshness, long enough to reduce DB load
- **Graceful degradation**: Cache failures are logged as warnings; app falls back to DB
- **Pipeline behaviors**: No changes needed to handler code; new queries just implement the marker interface